### PR TITLE
feat: add difficulty levels and progression system

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,6 +180,79 @@
       color: var(--cyan);
     }
 
+    .difficultyCard {
+      min-width: 168px;
+      --tier-accent: var(--rose);
+    }
+
+    .difficultyCard .value {
+      font-size: 17px;
+      color: var(--tier-accent);
+      text-shadow: 0 0 16px rgba(255, 93, 158, 0.22);
+    }
+
+    .subValue {
+      display: block;
+      margin-top: 6px;
+      font-size: 11px;
+      line-height: 1.2;
+      letter-spacing: 0.05em;
+      color: var(--muted);
+      text-transform: uppercase;
+    }
+
+    .progressCard {
+      min-width: min(100%, 320px);
+      width: min(100%, 340px);
+    }
+
+    .progressTop {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      margin-bottom: 7px;
+    }
+
+    .progressTop .label {
+      margin: 0;
+    }
+
+    .progressText {
+      font-size: 12px;
+      color: var(--ink);
+      font-weight: 700;
+      letter-spacing: 0.06em;
+    }
+
+    .waveProgressBar {
+      height: 9px;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,0.1);
+      background: rgba(255,255,255,0.03);
+      overflow: hidden;
+      position: relative;
+    }
+
+    .waveProgressFill {
+      height: 100%;
+      width: 0%;
+      border-radius: inherit;
+      background:
+        linear-gradient(90deg, rgba(94, 242, 255, 0.95), rgba(106, 160, 255, 0.95));
+      box-shadow: 0 0 14px rgba(94, 242, 255, 0.3);
+      transition: width 0.14s linear;
+    }
+
+    .progressMeta {
+      margin-top: 7px;
+      color: var(--muted);
+      font-size: 11px;
+      letter-spacing: 0.04em;
+      line-height: 1.2;
+      text-transform: uppercase;
+    }
+
     .hintCard {
       max-width: 300px;
       min-width: 240px;
@@ -349,6 +422,73 @@
       border: 1px solid rgba(255,255,255,0.05);
     }
 
+    .difficultyPicker {
+      margin-top: 16px;
+      padding: 12px;
+      border-radius: 14px;
+      background: rgba(255,255,255,0.03);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+
+    .pickerLabel {
+      display: block;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      color: var(--muted);
+    }
+
+    .difficultyOptions {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 8px;
+      margin-top: 8px;
+    }
+
+    .difficultyBtn {
+      min-width: 0;
+      padding: 10px 10px 9px;
+      border-radius: 10px;
+      border: 1px solid rgba(255,255,255,0.12);
+      background: rgba(255,255,255,0.03);
+      box-shadow: none;
+      text-align: left;
+    }
+
+    .difficultyBtn strong {
+      display: block;
+      font-size: 13px;
+      line-height: 1.1;
+    }
+
+    .difficultyBtn span {
+      display: block;
+      margin-top: 4px;
+      font-size: 11px;
+      line-height: 1.2;
+      color: var(--muted);
+      font-weight: 500;
+    }
+
+    .difficultyBtn.active {
+      background: linear-gradient(145deg, rgba(94, 242, 255, 0.95), rgba(106, 160, 255, 0.95));
+      color: #03131a;
+      border-color: rgba(94, 242, 255, 0.8);
+      box-shadow: 0 8px 18px rgba(45, 163, 255, 0.25);
+    }
+
+    .difficultyBtn.active span {
+      color: rgba(3, 19, 26, 0.72);
+    }
+
+    .difficultyHelp {
+      margin: 8px 2px 0;
+      min-height: 2.5em;
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.35;
+    }
+
     .actions {
       display: flex;
       gap: 10px;
@@ -417,6 +557,10 @@
         min-width: 92px;
       }
 
+      .difficultyCard {
+        min-width: 140px;
+      }
+
       .healthCard {
         min-width: min(100%, 240px);
         width: min(100%, 240px);
@@ -427,6 +571,10 @@
       }
 
       .controlsList {
+        grid-template-columns: 1fr;
+      }
+
+      .difficultyOptions {
         grid-template-columns: 1fr;
       }
 
@@ -468,6 +616,11 @@
         <span class="label">Wave</span>
         <span class="value" id="waveValue">1</span>
       </div>
+      <div class="card difficultyCard" id="difficultyCard">
+        <span class="label">Difficulty Tier</span>
+        <span class="value" id="difficultyValue">Medium I</span>
+        <span class="subValue" id="difficultySubValue">Base Medium • Tier 1</span>
+      </div>
       <div class="card">
         <span class="label">Time</span>
         <span class="value" id="timeValue">00:00</span>
@@ -484,6 +637,16 @@
       </div>
     </div>
     <div class="hudRow">
+      <div class="card progressCard">
+        <div class="progressTop">
+          <span class="label">Next Wave</span>
+          <span class="progressText" id="waveProgressText">0%</span>
+        </div>
+        <div class="waveProgressBar" aria-hidden="true">
+          <div class="waveProgressFill" id="waveProgressFill"></div>
+        </div>
+        <div class="progressMeta" id="progressMeta">Wave 1 to Wave 2 • 16s</div>
+      </div>
       <div class="card hintCard">
         <strong>Move</strong> <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> / arrows,
         <strong>Dash</strong> <kbd>Space</kbd>,
@@ -508,6 +671,26 @@
         <div><strong>Aim:</strong> Move mouse</div>
         <div><strong>Dash:</strong> Space (brief invulnerability)</div>
         <div><strong>Restart:</strong> Enter after game over</div>
+      </div>
+      <div class="difficultyPicker">
+        <span class="pickerLabel">Run Difficulty</span>
+        <div class="difficultyOptions" role="group" aria-label="Difficulty">
+          <button class="difficultyBtn" data-difficulty="easy" type="button" aria-pressed="false">
+            <strong>Easy</strong>
+            <span>Gentler ramp</span>
+          </button>
+          <button class="difficultyBtn active" data-difficulty="medium" type="button" aria-pressed="true">
+            <strong>Medium</strong>
+            <span>Balanced pace</span>
+          </button>
+          <button class="difficultyBtn" data-difficulty="hard" type="button" aria-pressed="false">
+            <strong>Hard</strong>
+            <span>Dense spawns</span>
+          </button>
+        </div>
+        <p class="difficultyHelp" id="difficultyHelp">
+          Medium starts balanced and ramps steadily with faster enemies and more frequent spawns each wave.
+        </p>
       </div>
       <div class="actions">
         <button class="primaryBtn" id="startBtn" type="button">Start Run</button>
@@ -555,9 +738,15 @@
         score: document.getElementById("scoreValue"),
         combo: document.getElementById("comboValue"),
         wave: document.getElementById("waveValue"),
+        difficultyCard: document.getElementById("difficultyCard"),
+        difficultyValue: document.getElementById("difficultyValue"),
+        difficultySubValue: document.getElementById("difficultySubValue"),
         time: document.getElementById("timeValue"),
         hpText: document.getElementById("hpText"),
         hpFill: document.getElementById("hpFill"),
+        waveProgressFill: document.getElementById("waveProgressFill"),
+        waveProgressText: document.getElementById("waveProgressText"),
+        progressMeta: document.getElementById("progressMeta"),
         waveBanner: document.getElementById("waveBanner"),
         menuOverlay: document.getElementById("menuOverlay"),
         gameOverOverlay: document.getElementById("gameOverOverlay"),
@@ -565,6 +754,8 @@
         restartBtn: document.getElementById("restartBtn"),
         backToMenuBtn: document.getElementById("backToMenuBtn"),
         menuMuteBtn: document.getElementById("menuMuteBtn"),
+        difficultyHelp: document.getElementById("difficultyHelp"),
+        difficultyButtons: Array.from(document.querySelectorAll(".difficultyBtn")),
         finalScore: document.getElementById("finalScore"),
         finalCombo: document.getElementById("finalCombo"),
         bestScore: document.getElementById("bestScore")
@@ -573,6 +764,47 @@
       const FX = {
         full: true
       };
+
+      const DIFFICULTY_PRESETS = {
+        easy: {
+          key: "easy",
+          label: "Easy",
+          description: "More breathing room early on. Slower ramp, fewer spawns, and slightly lower enemy speed.",
+          waveDuration: 18,
+          enemySpeedMul: 0.88,
+          enemyHpMul: 0.92,
+          spawnRateMul: 0.86,
+          maxEnemiesMul: 0.88,
+          scoreMul: 0.92,
+          rampMul: 0.85
+        },
+        medium: {
+          key: "medium",
+          label: "Medium",
+          description: "Balanced pacing with steady escalation. Waves add noticeable speed and spawn pressure.",
+          waveDuration: 16,
+          enemySpeedMul: 1,
+          enemyHpMul: 1,
+          spawnRateMul: 1,
+          maxEnemiesMul: 1,
+          scoreMul: 1,
+          rampMul: 1
+        },
+        hard: {
+          key: "hard",
+          label: "Hard",
+          description: "High pressure from the start. Faster enemies, denser spawns, and sharper wave scaling.",
+          waveDuration: 14,
+          enemySpeedMul: 1.12,
+          enemyHpMul: 1.12,
+          spawnRateMul: 1.18,
+          maxEnemiesMul: 1.18,
+          scoreMul: 1.12,
+          rampMul: 1.2
+        }
+      };
+      const TIER_SUFFIXES = ["I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"];
+      let selectedDifficultyKey = "medium";
 
       const input = {
         keys: Object.create(null),
@@ -622,6 +854,91 @@
         return String(m).padStart(2, "0") + ":" + String(s).padStart(2, "0");
       }
 
+      function getDifficultyPreset(key) {
+        return DIFFICULTY_PRESETS[key] || DIFFICULTY_PRESETS.medium;
+      }
+
+      function getTierSuffix(tier) {
+        return TIER_SUFFIXES[tier - 1] || String(tier);
+      }
+
+      function getTierAccent(tier) {
+        if (tier >= 5) return "#ff5578";
+        if (tier >= 4) return "#ff7d6a";
+        if (tier >= 3) return "#ffd15c";
+        if (tier >= 2) return "#7dff99";
+        return "#5ef2ff";
+      }
+
+      function getProgressionSnapshot(state) {
+        const preset = getDifficultyPreset(state.baseDifficultyKey || selectedDifficultyKey);
+        const waveDuration = preset.waveDuration;
+        const wave = 1 + Math.floor(state.time / waveDuration);
+        const waveProgress = (state.time % waveDuration) / waveDuration;
+        const timeToNextWave = Math.max(0, waveDuration - (state.time % waveDuration));
+        const tier = 1 + Math.floor((wave - 1) / 3);
+        const tierWave = ((wave - 1) % 3) + 1;
+        const rampIndex = Math.max(0, wave - 1);
+        const ramp = preset.rampMul;
+        const enemySpeedScale = preset.enemySpeedMul * (1 + rampIndex * 0.055 * ramp);
+        const enemyHpScale = preset.enemyHpMul * (1 + rampIndex * 0.045 * ramp);
+        const spawnRateScale = preset.spawnRateMul * (1 + rampIndex * 0.06 * ramp);
+        const maxEnemiesScale = preset.maxEnemiesMul * (1 + rampIndex * 0.05 * ramp);
+        const scoreScale = preset.scoreMul * (1 + rampIndex * 0.015 * ramp);
+
+        return {
+          preset,
+          wave,
+          waveDuration,
+          waveProgress,
+          timeToNextWave,
+          tier,
+          tierWave,
+          tierLabel: preset.label + " " + getTierSuffix(tier),
+          enemySpeedScale,
+          enemyHpScale,
+          spawnRateScale,
+          maxEnemiesScale,
+          scoreScale
+        };
+      }
+
+      function applyProgressionState(state) {
+        const snapshot = getProgressionSnapshot(state);
+        state.baseDifficultyKey = snapshot.preset.key;
+        state.baseDifficultyLabel = snapshot.preset.label;
+        state.wave = snapshot.wave;
+        state.waveDuration = snapshot.waveDuration;
+        state.waveProgress = snapshot.waveProgress;
+        state.timeToNextWave = snapshot.timeToNextWave;
+        state.difficultyTier = snapshot.tier;
+        state.difficultyTierLabel = snapshot.tierLabel;
+        state.progression = snapshot;
+        return snapshot;
+      }
+
+      function updateDifficultySelectionUI() {
+        const preset = getDifficultyPreset(selectedDifficultyKey);
+        if (ui.difficultyHelp) ui.difficultyHelp.textContent = preset.description;
+        ui.startBtn.textContent = "Start " + preset.label + " Run";
+        for (let i = 0; i < ui.difficultyButtons.length; i += 1) {
+          const btn = ui.difficultyButtons[i];
+          const isActive = btn.dataset.difficulty === selectedDifficultyKey;
+          btn.classList.toggle("active", isActive);
+          btn.setAttribute("aria-pressed", isActive ? "true" : "false");
+        }
+      }
+
+      function setSelectedDifficulty(nextKey) {
+        selectedDifficultyKey = getDifficultyPreset(nextKey).key;
+        updateDifficultySelectionUI();
+        if (game && game.mode === "menu") {
+          game.baseDifficultyKey = selectedDifficultyKey;
+          applyProgressionState(game);
+          updateHud();
+        }
+      }
+
       function resize() {
         world.w = window.innerWidth;
         world.h = window.innerHeight;
@@ -658,12 +975,16 @@
       }
 
       function freshGameState() {
-        return {
+        const preset = getDifficultyPreset(selectedDifficultyKey);
+        const state = {
           mode: "menu",
           time: 0,
           score: 0,
           wave: 1,
           waveShown: 1,
+          waveProgress: 0,
+          waveDuration: preset.waveDuration,
+          timeToNextWave: preset.waveDuration,
           kills: 0,
           combo: 0,
           comboTimer: 0,
@@ -672,6 +993,11 @@
           spawnBudget: 0,
           shake: 0,
           heat: 0,
+          baseDifficultyKey: preset.key,
+          baseDifficultyLabel: preset.label,
+          difficultyTier: 1,
+          difficultyTierLabel: preset.label + " I",
+          progression: null,
           player: makePlayer(),
           enemies: [],
           projectiles: [],
@@ -679,14 +1005,16 @@
           particles: [],
           ripples: []
         };
+        applyProgressionState(state);
+        return state;
       }
 
       function resetRun() {
         game = freshGameState();
         game.mode = "running";
-        game.wave = 1;
-        game.waveShown = 1;
-        showWaveBanner("Wave 1");
+        const snapshot = applyProgressionState(game);
+        game.waveShown = snapshot.wave;
+        showWaveBanner("Wave " + snapshot.wave + " • " + snapshot.tierLabel);
         ui.menuOverlay.classList.remove("show");
         ui.gameOverOverlay.classList.remove("show");
         updateHud();
@@ -777,8 +1105,14 @@
         });
       }
 
-      function currentWaveFromTime() {
-        return 1 + Math.floor(game.time / 16);
+      function applyEnemyProgression(enemy) {
+        const prog = game.progression || applyProgressionState(game);
+        const accelScale = clamp(0.9 + (prog.enemySpeedScale - 1) * 0.65 + 0.12, 0.85, 1.75);
+        enemy.speed *= prog.enemySpeedScale * rand(0.97, 1.04);
+        enemy.accel *= accelScale;
+        enemy.hp = Math.max(1, Math.round(enemy.hp * prog.enemyHpScale));
+        enemy.maxHp = enemy.hp;
+        enemy.value = Math.max(1, Math.round(enemy.value * prog.scoreScale));
       }
 
       function spawnEnemy(typeOverride) {
@@ -811,8 +1145,9 @@
           hitFlash: 0
         };
 
+        let enemy;
         if (type === "tank") {
-          game.enemies.push({
+          enemy = {
             ...common,
             type,
             r: rand(20, 25),
@@ -823,9 +1158,9 @@
             value: 28,
             hue: 330,
             touchDamage: 2
-          });
+          };
         } else if (type === "orbiter") {
-          game.enemies.push({
+          enemy = {
             ...common,
             type,
             r: rand(13, 17),
@@ -837,9 +1172,9 @@
             hue: 195,
             orbitDir: Math.random() < 0.5 ? -1 : 1,
             touchDamage: 1
-          });
+          };
         } else if (type === "splitter") {
-          game.enemies.push({
+          enemy = {
             ...common,
             type,
             r: rand(15, 18),
@@ -850,9 +1185,9 @@
             value: 22,
             hue: 275,
             touchDamage: 1
-          });
+          };
         } else if (type === "mini") {
-          game.enemies.push({
+          enemy = {
             ...common,
             type,
             r: rand(8, 10),
@@ -863,9 +1198,9 @@
             value: 7,
             hue: 50,
             touchDamage: 1
-          });
+          };
         } else {
-          game.enemies.push({
+          enemy = {
             ...common,
             type: "chaser",
             r: rand(10, 13),
@@ -876,8 +1211,11 @@
             value: 12,
             hue: 345,
             touchDamage: 1
-          });
+          };
         }
+
+        applyEnemyProgression(enemy);
+        game.enemies.push(enemy);
       }
 
       function fireBolt() {
@@ -1088,10 +1426,11 @@
         game.heat = Math.max(0, game.heat - dt * 0.08);
         game.shake = Math.max(0, game.shake - dt * 18);
 
-        const nextWave = currentWaveFromTime();
-        if (nextWave !== game.wave) {
-          game.wave = nextWave;
-          showWaveBanner("Wave " + game.wave);
+        const prevWave = game.wave;
+        const progression = applyProgressionState(game);
+        if (progression.wave !== prevWave) {
+          showWaveBanner("Wave " + progression.wave + " • " + progression.tierLabel);
+          game.spawnTimer = Math.min(game.spawnTimer, 0.12);
         }
 
         let moveX = 0;
@@ -1164,11 +1503,21 @@
         }
 
         game.spawnTimer -= dt;
-        const targetOnScreen = 2 + Math.floor(game.wave * 1.35);
-        if (game.spawnTimer <= 0 && game.enemies.length < targetOnScreen + 3) {
+        const targetOnScreen = Math.max(3, Math.round((2 + Math.floor(game.wave * 1.35)) * progression.maxEnemiesScale));
+        const spawnCap = targetOnScreen + 2 + Math.floor(progression.tier * 0.75);
+        if (game.spawnTimer <= 0 && game.enemies.length < spawnCap) {
           spawnEnemy();
-          const interval = clamp(0.8 - game.wave * 0.04, 0.18, 0.8);
-          game.spawnTimer = interval * rand(0.65, 1.15);
+          if (
+            progression.tier >= 2 &&
+            progression.tierWave === 1 &&
+            game.enemies.length < spawnCap &&
+            Math.random() < clamp(0.1 + progression.tier * 0.04, 0.1, 0.28)
+          ) {
+            spawnEnemy();
+          }
+          const baseInterval = clamp(0.84 - game.wave * 0.028, 0.12, 0.84);
+          const interval = clamp(baseInterval / progression.spawnRateScale, 0.09, 0.9);
+          game.spawnTimer = interval * rand(0.68, 1.12);
         }
 
         for (let i = game.projectiles.length - 1; i >= 0; i -= 1) {
@@ -1359,13 +1708,28 @@
 
       function updateHud() {
         if (!game) return;
+        const prog = game.progression || applyProgressionState(game);
         ui.score.textContent = String(Math.floor(game.score));
-        ui.wave.textContent = String(game.wave);
+        ui.wave.textContent = String(prog.wave);
         ui.time.textContent = fmtTime(game.time);
         const comboMul = 1 + game.combo * 0.18;
         ui.combo.textContent = "x" + comboMul.toFixed(1);
         ui.hpText.textContent = game.player.hp + " / " + game.player.maxHp;
         ui.hpFill.style.width = (game.player.hp / game.player.maxHp * 100).toFixed(1) + "%";
+
+        const speedDelta = Math.round((prog.enemySpeedScale - 1) * 100);
+        const spawnDelta = Math.round((prog.spawnRateScale - 1) * 100);
+        const speedDeltaText = (speedDelta >= 0 ? "+" : "") + speedDelta + "%";
+        const spawnDeltaText = (spawnDelta >= 0 ? "+" : "") + spawnDelta + "%";
+
+        ui.difficultyCard.style.setProperty("--tier-accent", getTierAccent(prog.tier));
+        ui.difficultyValue.textContent = prog.tierLabel;
+        ui.difficultySubValue.textContent = "Base " + prog.preset.label + " • T" + prog.tier + " • " + speedDeltaText + " Speed";
+
+        ui.waveProgressFill.style.width = (prog.waveProgress * 100).toFixed(1) + "%";
+        ui.waveProgressText.textContent = Math.round(prog.waveProgress * 100) + "%";
+        ui.progressMeta.textContent =
+          "Wave " + prog.wave + " -> " + (prog.wave + 1) + " • " + Math.ceil(prog.timeToNextWave) + "s • Spawn " + spawnDeltaText;
       }
 
       function drawBackground() {
@@ -1746,6 +2110,13 @@
         input.pointerActive = false;
       });
 
+      for (let i = 0; i < ui.difficultyButtons.length; i += 1) {
+        const btn = ui.difficultyButtons[i];
+        btn.addEventListener("click", () => {
+          setSelectedDifficulty(btn.dataset.difficulty);
+        });
+      }
+
       ui.startBtn.addEventListener("click", () => resetRun());
       ui.restartBtn.addEventListener("click", () => resetRun());
       ui.backToMenuBtn.addEventListener("click", () => backToMenu());
@@ -1761,6 +2132,7 @@
       });
 
       resize();
+      updateDifficultySelectionUI();
       backToMenu();
       updateHud();
       if (rafId) cancelAnimationFrame(rafId);


### PR DESCRIPTION
## Summary
- add Easy/Medium/Hard difficulty selection in the menu
- add a progression HUD with current difficulty tier and next-wave progress bar
- scale enemy stats and spawn pressure over time by wave/tier and selected difficulty

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added difficulty selection system (Easy/Medium/Hard) with runtime switching capability.
  * Enemy stats now scale dynamically with selected difficulty (speed, health, spawn rate).
  * Introduced difficulty tier progression system with visual tier indicators and labels.
  * Added wave progress bar displaying current tier and speed multiplier information.
  * Scoring adjusts based on selected difficulty level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->