### PR TITLE
feat: add soundtrack and retro sound effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,6 +398,33 @@
       color: var(--cyan);
     }
 
+    .audioDock {
+      position: fixed;
+      right: 14px;
+      bottom: 14px;
+      z-index: 5;
+      pointer-events: auto;
+    }
+
+    .audioBtn {
+      min-width: 0;
+      padding: 10px 12px;
+      border-radius: 999px;
+      background: rgba(8, 18, 33, 0.86);
+      border: 1px solid rgba(94, 242, 255, 0.24);
+      color: var(--ink);
+      box-shadow: 0 12px 28px rgba(0,0,0,0.34);
+      backdrop-filter: blur(10px);
+      font-size: 12px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    .audioBtn[aria-pressed="true"] {
+      color: var(--muted);
+      border-color: rgba(255,255,255,0.14);
+    }
+
     @media (max-width: 860px) {
       .hud {
         grid-template-columns: 1fr;
@@ -409,6 +436,11 @@
 
       .waveBanner {
         top: 134px;
+      }
+
+      .audioDock {
+        right: 12px;
+        bottom: 12px;
       }
     }
 
@@ -495,6 +527,16 @@
 
   <div class="waveBanner" id="waveBanner">Wave 1</div>
 
+  <div class="audioDock">
+    <button
+      class="audioBtn"
+      id="audioToggleBtn"
+      type="button"
+      aria-label="Toggle audio volume"
+      aria-pressed="false"
+    >Audio: High</button>
+  </div>
+
   <section class="overlay show" id="menuOverlay" aria-labelledby="menuTitle">
     <div class="panel">
       <p class="eyebrow">Browser Arcade</p>
@@ -559,6 +601,7 @@
         hpText: document.getElementById("hpText"),
         hpFill: document.getElementById("hpFill"),
         waveBanner: document.getElementById("waveBanner"),
+        audioToggleBtn: document.getElementById("audioToggleBtn"),
         menuOverlay: document.getElementById("menuOverlay"),
         gameOverOverlay: document.getElementById("gameOverOverlay"),
         startBtn: document.getElementById("startBtn"),
@@ -598,6 +641,462 @@
       } catch (_) {
         bestScore = 0;
       }
+      const audioVolumeKey = "neon-core-rush-audio-volume";
+
+      function createAudioSystem() {
+        const AudioCtx = window.AudioContext || window.webkitAudioContext;
+        const volumeLevels = [0, 0.22, 0.48];
+        const volumeLabels = ["Mute", "Low", "High"];
+        let volumeIndex = 2;
+
+        try {
+          const stored = Number(localStorage.getItem(audioVolumeKey));
+          if (Number.isFinite(stored) && stored >= 0 && stored < volumeLevels.length) {
+            volumeIndex = stored;
+          }
+        } catch (_) {
+          volumeIndex = 2;
+        }
+
+        const state = {
+          supported: Boolean(AudioCtx),
+          ctx: null,
+          master: null,
+          musicBus: null,
+          sfxBus: null,
+          nextStepTime: 0,
+          step: 0,
+          tempo: 108,
+          lookAhead: 0.3
+        };
+
+        const bassPattern = [40, null, 40, null, 43, null, 47, null, 38, null, 38, null, 43, null, 45, null];
+        const leadPattern = [64, 67, 71, 74, 76, 74, 71, 67, 62, 66, 69, 74, 71, 69, 66, 62];
+        const chordPattern = [
+          [52, 55, 59],
+          [50, 54, 57],
+          [48, 52, 55],
+          [50, 54, 57]
+        ];
+
+        function currentLevel() {
+          return volumeLevels[volumeIndex];
+        }
+
+        function isAudible() {
+          return currentLevel() > 0.0001;
+        }
+
+        function stepDuration() {
+          return 60 / state.tempo / 2;
+        }
+
+        function midiToHz(midi) {
+          return 440 * Math.pow(2, (midi - 69) / 12);
+        }
+
+        function persistVolume() {
+          try {
+            localStorage.setItem(audioVolumeKey, String(volumeIndex));
+          } catch (_) {
+            /* ignore storage failures */
+          }
+        }
+
+        function updateButton() {
+          if (!ui.audioToggleBtn) return;
+          if (!state.supported) {
+            ui.audioToggleBtn.textContent = "Audio: Off";
+            ui.audioToggleBtn.disabled = true;
+            ui.audioToggleBtn.setAttribute("aria-pressed", "true");
+            return;
+          }
+          ui.audioToggleBtn.textContent = "Audio: " + volumeLabels[volumeIndex];
+          ui.audioToggleBtn.disabled = false;
+          ui.audioToggleBtn.setAttribute("aria-pressed", String(volumeIndex === 0));
+          ui.audioToggleBtn.setAttribute("aria-label", "Audio volume " + volumeLabels[volumeIndex] + ". Click to cycle.");
+        }
+
+        function createGraph() {
+          if (!state.supported || state.ctx) return;
+
+          state.ctx = new AudioCtx();
+
+          const master = state.ctx.createGain();
+          const musicBus = state.ctx.createGain();
+          const sfxBus = state.ctx.createGain();
+          const limiter = state.ctx.createDynamicsCompressor();
+
+          limiter.threshold.value = -20;
+          limiter.knee.value = 16;
+          limiter.ratio.value = 10;
+          limiter.attack.value = 0.003;
+          limiter.release.value = 0.18;
+
+          master.gain.value = 0;
+          musicBus.gain.value = 0.42;
+          sfxBus.gain.value = 0.9;
+
+          musicBus.connect(master);
+          sfxBus.connect(master);
+          master.connect(limiter);
+          limiter.connect(state.ctx.destination);
+
+          state.master = master;
+          state.musicBus = musicBus;
+          state.sfxBus = sfxBus;
+          state.nextStepTime = state.ctx.currentTime + 0.06;
+          state.step = 0;
+        }
+
+        function applyVolume() {
+          if (!state.ctx || !state.master) return;
+          const now = state.ctx.currentTime;
+          state.master.gain.cancelScheduledValues(now);
+          state.master.gain.setTargetAtTime(currentLevel(), now, 0.025);
+        }
+
+        function ensure() {
+          if (!state.supported) return false;
+          createGraph();
+          if (!state.ctx) return false;
+          if (state.ctx.state === "suspended") {
+            state.ctx.resume().catch(() => {});
+          }
+          applyVolume();
+          return true;
+        }
+
+        function disposeNodes(nodes) {
+          nodes.forEach((node) => {
+            if (!node) return;
+            try { node.disconnect(); } catch (_) { /* ignore */ }
+          });
+        }
+
+        function synthTone(target, opts) {
+          if (!state.ctx || !target) return;
+
+          const when = Math.max(opts.time ?? state.ctx.currentTime, state.ctx.currentTime);
+          const osc = state.ctx.createOscillator();
+          const amp = state.ctx.createGain();
+          let finalNode = amp;
+          let filter = null;
+
+          osc.type = opts.type || "square";
+          osc.frequency.setValueAtTime(opts.freq, when);
+          if (opts.freqEnd && opts.freqEnd > 0) {
+            osc.frequency.exponentialRampToValueAtTime(opts.freqEnd, when + (opts.duration || 0.08));
+          }
+          if (opts.detune) {
+            osc.detune.setValueAtTime(opts.detune, when);
+          }
+
+          if (opts.filter) {
+            filter = state.ctx.createBiquadFilter();
+            filter.type = opts.filter.type || "lowpass";
+            filter.frequency.setValueAtTime(opts.filter.freq || 1200, when);
+            if (opts.filter.q != null) filter.Q.value = opts.filter.q;
+            osc.connect(filter);
+            filter.connect(amp);
+          } else {
+            osc.connect(amp);
+          }
+
+          const attack = opts.attack ?? 0.004;
+          const hold = opts.duration ?? 0.06;
+          const release = opts.release ?? 0.05;
+          const peak = Math.max(0.0001, opts.gain ?? 0.03);
+
+          amp.gain.setValueAtTime(0.0001, when);
+          amp.gain.linearRampToValueAtTime(peak, when + attack);
+          amp.gain.exponentialRampToValueAtTime(0.0001, when + hold + release);
+
+          finalNode.connect(target);
+          osc.start(when);
+          osc.stop(when + hold + release + 0.02);
+          osc.addEventListener("ended", () => disposeNodes([osc, filter, amp]));
+        }
+
+        function scheduleKick(time) {
+          synthTone(state.musicBus, {
+            time,
+            type: "sine",
+            freq: 130,
+            freqEnd: 42,
+            duration: 0.16,
+            gain: 0.11,
+            attack: 0.003,
+            release: 0.06
+          });
+        }
+
+        function scheduleHat(time) {
+          synthTone(state.musicBus, {
+            time,
+            type: "square",
+            freq: 4600,
+            duration: 0.012,
+            gain: 0.01,
+            attack: 0.001,
+            release: 0.012,
+            filter: { type: "highpass", freq: 2500, q: 0.7 }
+          });
+          synthTone(state.musicBus, {
+            time: time + 0.016,
+            type: "square",
+            freq: 3600,
+            duration: 0.01,
+            gain: 0.007,
+            attack: 0.001,
+            release: 0.01,
+            filter: { type: "highpass", freq: 2200, q: 0.6 }
+          });
+        }
+
+        function scheduleChord(time, midiNotes) {
+          const gate = stepDuration() * 1.9;
+          for (let i = 0; i < midiNotes.length; i += 1) {
+            const detune = i === 0 ? -4 : i === 1 ? 0 : 5;
+            synthTone(state.musicBus, {
+              time,
+              type: "sawtooth",
+              freq: midiToHz(midiNotes[i]),
+              detune,
+              duration: gate,
+              gain: i === 0 ? 0.018 : 0.014,
+              attack: 0.012,
+              release: 0.09,
+              filter: { type: "lowpass", freq: 1200, q: 0.35 }
+            });
+          }
+        }
+
+        function scheduleLead(time, midi) {
+          const baseGain = 0.034;
+          const hz = midiToHz(midi);
+          synthTone(state.musicBus, {
+            time,
+            type: "square",
+            freq: hz,
+            duration: stepDuration() * 0.68,
+            gain: baseGain,
+            attack: 0.002,
+            release: 0.04,
+            filter: { type: "lowpass", freq: 3200, q: 0.5 }
+          });
+          synthTone(state.musicBus, {
+            time: time + stepDuration() * 0.5,
+            type: "square",
+            freq: hz,
+            duration: stepDuration() * 0.35,
+            gain: baseGain * 0.35,
+            attack: 0.002,
+            release: 0.03,
+            filter: { type: "lowpass", freq: 2600, q: 0.4 }
+          });
+        }
+
+        function scheduleBass(time, midi) {
+          synthTone(state.musicBus, {
+            time,
+            type: "triangle",
+            freq: midiToHz(midi),
+            duration: stepDuration() * 0.88,
+            gain: 0.05,
+            attack: 0.003,
+            release: 0.05,
+            filter: { type: "lowpass", freq: 620, q: 0.25 }
+          });
+        }
+
+        function scheduleMusicStep(time, stepIndex) {
+          const step = stepIndex % 16;
+          if (step % 4 === 0) scheduleKick(time);
+          if (step % 2 === 1) scheduleHat(time);
+
+          const bass = bassPattern[step];
+          if (bass != null) scheduleBass(time, bass);
+
+          const lead = leadPattern[step];
+          if (lead != null) scheduleLead(time + (step % 4 === 3 ? 0.01 : 0), lead);
+
+          if (step % 4 === 0) {
+            scheduleChord(time, chordPattern[(step / 4) % chordPattern.length]);
+          }
+        }
+
+        function tick() {
+          if (!state.ctx || !state.musicBus || !state.master) return;
+          if (state.ctx.state !== "running" || !isAudible()) return;
+
+          const now = state.ctx.currentTime;
+          const stepLen = stepDuration();
+          if (!Number.isFinite(state.nextStepTime) || state.nextStepTime < now - stepLen) {
+            state.nextStepTime = now + 0.05;
+          }
+
+          while (state.nextStepTime < now + state.lookAhead) {
+            scheduleMusicStep(state.nextStepTime, state.step);
+            state.nextStepTime += stepLen;
+            state.step += 1;
+          }
+        }
+
+        function playMenu() {
+          if (!ensure() || !isAudible()) return;
+          const t = state.ctx.currentTime + 0.004;
+          synthTone(state.sfxBus, {
+            time: t,
+            type: "square",
+            freq: 720,
+            duration: 0.024,
+            gain: 0.035,
+            attack: 0.002,
+            release: 0.018
+          });
+          synthTone(state.sfxBus, {
+            time: t + 0.038,
+            type: "square",
+            freq: 980,
+            duration: 0.02,
+            gain: 0.028,
+            attack: 0.002,
+            release: 0.016
+          });
+        }
+
+        function playCollect(kind) {
+          if (!ensure() || !isAudible()) return;
+          const t = state.ctx.currentTime + 0.003;
+          if (kind === "heal") {
+            [660, 880, 1108].forEach((freq, index) => {
+              synthTone(state.sfxBus, {
+                time: t + index * 0.028,
+                type: "triangle",
+                freq,
+                duration: 0.045,
+                gain: 0.033,
+                attack: 0.002,
+                release: 0.035
+              });
+            });
+            return;
+          }
+          synthTone(state.sfxBus, {
+            time: t,
+            type: "square",
+            freq: 540,
+            duration: 0.018,
+            gain: 0.03,
+            attack: 0.002,
+            release: 0.02
+          });
+          synthTone(state.sfxBus, {
+            time: t + 0.022,
+            type: "square",
+            freq: 820,
+            duration: 0.02,
+            gain: 0.026,
+            attack: 0.002,
+            release: 0.02
+          });
+        }
+
+        function playHit() {
+          if (!ensure() || !isAudible()) return;
+          const t = state.ctx.currentTime + 0.002;
+          synthTone(state.sfxBus, {
+            time: t,
+            type: "sawtooth",
+            freq: 230,
+            freqEnd: 95,
+            duration: 0.09,
+            gain: 0.065,
+            attack: 0.002,
+            release: 0.05,
+            filter: { type: "lowpass", freq: 900, q: 0.4 }
+          });
+          synthTone(state.sfxBus, {
+            time: t + 0.012,
+            type: "square",
+            freq: 120,
+            duration: 0.06,
+            gain: 0.028,
+            attack: 0.002,
+            release: 0.03
+          });
+        }
+
+        function playGameOver() {
+          if (!ensure() || !isAudible()) return;
+          const t = state.ctx.currentTime + 0.01;
+          [523, 392, 294, 220].forEach((freq, index) => {
+            synthTone(state.sfxBus, {
+              time: t + index * 0.11,
+              type: index % 2 ? "triangle" : "square",
+              freq,
+              duration: 0.08,
+              gain: 0.044 - index * 0.006,
+              attack: 0.003,
+              release: 0.06
+            });
+          });
+          synthTone(state.sfxBus, {
+            time: t + 0.36,
+            type: "sawtooth",
+            freq: 180,
+            freqEnd: 72,
+            duration: 0.24,
+            gain: 0.05,
+            attack: 0.003,
+            release: 0.08,
+            filter: { type: "lowpass", freq: 760, q: 0.45 }
+          });
+        }
+
+        function cycleVolume() {
+          if (!state.supported) {
+            updateButton();
+            return;
+          }
+
+          volumeIndex = (volumeIndex + 1) % volumeLevels.length;
+          persistVolume();
+          if (currentLevel() > 0) ensure();
+          applyVolume();
+          updateButton();
+          if (currentLevel() > 0) playMenu();
+        }
+
+        function handleVisibility() {
+          if (!state.ctx) return;
+          if (document.hidden) {
+            state.ctx.suspend().catch(() => {});
+            return;
+          }
+          if (currentLevel() > 0) {
+            state.nextStepTime = state.ctx.currentTime + 0.06;
+            state.ctx.resume().catch(() => {});
+          }
+        }
+
+        updateButton();
+
+        return {
+          ensure,
+          tick,
+          playMenu,
+          playCollect,
+          playHit,
+          playGameOver,
+          cycleVolume,
+          updateButton,
+          handleVisibility
+        };
+      }
+
+      const audio = createAudioSystem();
 
       let game = null;
       let lastFrame = performance.now();
@@ -702,6 +1201,7 @@
       function showGameOver() {
         if (!game || game.mode === "gameover") return;
         game.mode = "gameover";
+        audio.playGameOver();
         if (game.score > bestScore) {
           bestScore = game.score;
           try {
@@ -989,6 +1489,7 @@
         game.combo = Math.max(0, Math.floor(game.combo * 0.35));
         game.comboTimer = Math.min(game.comboTimer, 0.9);
         game.heat = Math.min(1, game.heat + 0.22);
+        audio.playHit();
 
         if (source) {
           const dx = p.x - source.x;
@@ -1223,6 +1724,7 @@
               game.comboTimer = Math.max(game.comboTimer, 2.2);
               spawnParticle(pick.x, pick.y, { count: 8, speed: 120, size: 2.6, life: 0.28, hue: 48, light: 70 });
             }
+            audio.playCollect(pick.kind);
             game.pickups.splice(i, 1);
           }
         }
@@ -1700,6 +2202,7 @@
           }
         }
 
+        audio.tick();
         renderFrame();
         rafId = requestAnimationFrame(loop);
       }
@@ -1712,6 +2215,7 @@
 
       window.addEventListener("keydown", (event) => {
         preventScrollKeys(event);
+        audio.ensure();
         input.keys[event.code] = true;
 
         if (event.code === "Space") {
@@ -1719,8 +2223,13 @@
         }
 
         if (event.code === "Enter") {
-          if (game && game.mode === "gameover") resetRun();
-          else if (game && game.mode === "menu") resetRun();
+          if (game && game.mode === "gameover") {
+            audio.playMenu();
+            resetRun();
+          } else if (game && game.mode === "menu") {
+            audio.playMenu();
+            resetRun();
+          }
         }
       });
 
@@ -1736,6 +2245,7 @@
       });
 
       canvas.addEventListener("pointerdown", (event) => {
+        audio.ensure();
         const rect = canvas.getBoundingClientRect();
         input.mouseX = event.clientX - rect.left;
         input.mouseY = event.clientY - rect.top;
@@ -1746,10 +2256,27 @@
         input.pointerActive = false;
       });
 
-      ui.startBtn.addEventListener("click", () => resetRun());
-      ui.restartBtn.addEventListener("click", () => resetRun());
-      ui.backToMenuBtn.addEventListener("click", () => backToMenu());
+      ui.startBtn.addEventListener("click", () => {
+        audio.ensure();
+        audio.playMenu();
+        resetRun();
+      });
+      ui.restartBtn.addEventListener("click", () => {
+        audio.ensure();
+        audio.playMenu();
+        resetRun();
+      });
+      ui.backToMenuBtn.addEventListener("click", () => {
+        audio.ensure();
+        audio.playMenu();
+        backToMenu();
+      });
+      ui.audioToggleBtn.addEventListener("click", () => {
+        audio.cycleVolume();
+      });
       ui.menuMuteBtn.addEventListener("click", () => {
+        audio.ensure();
+        audio.playMenu();
         FX.full = !FX.full;
         ui.menuMuteBtn.textContent = FX.full ? "Toggle Glow FX" : "Enable Glow FX";
       });
@@ -1759,6 +2286,7 @@
         Object.keys(input.keys).forEach((k) => { input.keys[k] = false; });
         input.dashQueued = false;
       });
+      document.addEventListener("visibilitychange", audio.handleVisibility);
 
       resize();
       backToMenu();


### PR DESCRIPTION
## Summary
- add Web Audio API retro/chiptune background music scheduler (synth lead, bass, drums)
- add retro SFX for collect, hit, game over, and menu interactions
- add a global audio volume toggle button (High/Low/Mute) with localStorage persistence

## Testing
- parsed inline script with Node (`new Function(...)`)
- Playwright smoke test could not run in this session because the CLI wrapper hung during startup/package fetch

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a complete in-game audio system with dynamic sound effects and background music
  * Introduced three-tier volume control (Mute, Low, High) that persists across sessions
  * Added audio toggle button to the user interface for convenient control
  * Integrated immersive sound effects for key gameplay events (collecting items, collisions, game over)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->