### PR TITLE
feat: add persistent top-5 scoreboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1786,7 +1786,10 @@
 
         if (!loaded.length) {
           try {
-            const legacyBest = Math.max(0, Math.floor(Number(localStorage.getItem(bestScoreKey)) || 0));
+            const rawLegacyBest = Number(localStorage.getItem(bestScoreKey));
+            const legacyBest = Number.isFinite(rawLegacyBest)
+              ? Math.max(0, Math.floor(rawLegacyBest))
+              : 0;
             if (legacyBest > 0) {
               loaded = [{ initials: "AAA", score: legacyBest, createdAt: 0 }];
             }


### PR DESCRIPTION
## Summary
- add a game-over scoreboard panel that shows the top 5 local scores with initials
- persist high scores in localStorage and migrate the legacy best-score value when present
- prompt for player initials when a run qualifies for the top 5 and keep the best score tile in sync

## Testing
- node --check on extracted inline script from index.html

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local top-5 high-score leaderboard on the Game Over screen with dynamic messages.
  * Players can enter and persist initials; last-entered initials are remembered and auto-focused when needed.
  * Prompts for initials on new high scores, with input sanitization and Enter/keyboard handling.
  * Scoreboard updates on Game Over, Reset, and Back-to-Menu; pending score saves are handled and migrated from the previous single best-score.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->